### PR TITLE
Update Docker image and Spotifyd to v0.4.2 with OAuth auth

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -22,24 +22,24 @@ jobs:
     steps:
       # Get the repository's code
       - name: Checkout
-        uses: actions/checkout@v3.0.1
+        uses: actions/checkout@v6
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1.2.0
+        uses: docker/setup-qemu-action@v3
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1.6.0
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1.14.1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
           
       - name: Docker meta
         id: spotifyd # you'll use this in the next step
-        uses: docker/metadata-action@v3.7.0
+        uses: docker/metadata-action@v5
         with:
           # list of Docker images to use as base name for tags
           images: |
@@ -56,7 +56,7 @@ jobs:
           #  type=sha
       
       - name: Build and push
-        uses: docker/build-push-action@v2.10.0
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/arm/v7

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18.4 AS build
+FROM alpine:3.21.6 AS build
 ARG CARGO_NET_GIT_FETCH_WITH_CLI=true
 RUN apk -U --no-cache add \
 	git \
@@ -7,9 +7,8 @@ RUN apk -U --no-cache add \
 	autoconf \
 	automake \
 	libtool \
-	libdaemon-dev \
 	alsa-lib-dev \
-	libressl-dev \
+	openssl-dev \
 	libconfig-dev \
 	libstdc++ \
 	gcc \
@@ -18,9 +17,9 @@ RUN apk -U --no-cache add \
 
 RUN cd /root \ 
 && git clone https://github.com/Spotifyd/spotifyd . \
-&& git checkout tags/v0.3.5 \
+&& git checkout tags/v0.4.2 \
 && cargo build --release
-FROM alpine:3.18.4
+FROM alpine:3.21.6
 RUN apk -U --no-cache add \
         libtool \
         libconfig-dev \

--- a/spotifyd.conf
+++ b/spotifyd.conf
@@ -1,24 +1,7 @@
 [global]
-# Your Spotify account name.
-username = username
-
-# Your Spotify account password.
-password = password
-
-# A command that gets executed and can be used to
-# retrieve your password.
-# The command should return the password on stdout.
-#
-# This is an alternative to the `password` field. Both
-# can't be used simultaneously.
-password_cmd = command_that_writes_password_to_stdout
-
-# If set to true, `spotifyd` tries to look up your
-# password in the system's password storage.
-#
-# This is an alternative to the `password` field. Both
-# can't be used simultaneously.
-use_keyring = true
+# Authentication: Spotifyd v0.4.x uses OAuth instead of username/password.
+# Run `spotifyd auth` once to authenticate via a web-based flow.
+# Credentials are cached automatically after the initial login.
 
 # The audio backend used to play the your music. To get
 # a list of possible backends, run `spotifyd --help`.


### PR DESCRIPTION
## Summary
This PR updates the Spotifyd Docker image to use the latest version (v0.4.2) along with modernized base images and GitHub Actions. The update includes a significant authentication change from username/password to OAuth-based authentication.

## Key Changes

### Docker & CI/CD Updates
- Updated all GitHub Actions to their latest major versions:
  - `actions/checkout@v3.0.1` → `v6`
  - `docker/setup-qemu-action@v1.2.0` → `v3`
  - `docker/setup-buildx-action@v1.6.0` → `v3`
  - `docker/login-action@v1.14.1` → `v3`
  - `docker/metadata-action@v3.7.0` → `v5`
  - `docker/build-push-action@v2.10.0` → `v6`
- Updated Alpine base image from `3.18.4` to `3.21.6` (both build and runtime stages)

### Spotifyd Application Updates
- Upgraded Spotifyd from `v0.3.5` to `v0.4.2`
- Updated dependencies to match v0.4.2 requirements:
  - Removed `libdaemon-dev` (no longer needed)
  - Replaced `libressl-dev` with `openssl-dev` (upstream change)

### Authentication Configuration
- Updated `spotifyd.conf` to reflect v0.4.2's OAuth authentication model
- Removed legacy username/password configuration fields
- Added instructions for OAuth-based authentication via `spotifyd auth` command
- Credentials are now cached automatically after initial login

## Notes
The authentication change is a breaking change for existing deployments. Users will need to run the OAuth authentication flow once before the service can connect to Spotify.

https://claude.ai/code/session_013rySnzAnbTLzqFLkEftL6z